### PR TITLE
Fix No Redirect After Delete On A Show Page Bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -4194,20 +4194,21 @@ function isShowPage(url) {
 - `puravida middleware/currentOrAdmin-index.js ~`
 ```
 export default function ({ route, store, redirect }) {
-  const { isAdmin, loggedInUser } = store.getters
+  const { isAdmin, loggedInUser, isAuthenticated } = store.getters
   const query = route.query
-  const isAdminRequest = query['admin'] ? true : false
-  const isUserIdRequest = query['user_id'] ? true : false
   const isQueryEmpty = Object.keys(query).length === 0 ? true : false
-  const userIdRequestButNotAdmin = isUserIdRequest && !isAdmin
   const requested_user_id = parseInt(query['user_id'])
   const actual_user_id = loggedInUser.id
-  const allowedAccess = requested_user_id === actual_user_id ? true : false
+  const isUserRequestingOwnData = requested_user_id === actual_user_id
+  const pathWithoutQuery = route.path.split('?')[0]
 
-  if ((isAdminRequest || isQueryEmpty) && !isAdmin) {
+  if (!isAuthenticated) {
     return redirect('/')
-  } else if (userIdRequestButNotAdmin && !allowedAccess) {
-    return redirect('/cars?user_id=' + loggedInUser.id)
+  } else if (!isAdmin && !isQueryEmpty && !isUserRequestingOwnData) {
+    const pathWithUserId = `${pathWithoutQuery}?user_id=${loggedInUser.id}`
+    return redirect(pathWithUserId)
+  } else if (isQueryEmpty) {
+    return redirect(pathWithoutQuery)
   }
 }
 ~
@@ -4542,7 +4543,7 @@ export default {
       this.$axios.$delete(`cars/${id}`)
       const index = this.cars.findIndex((i) => { return i.id === id })
       this.cars.splice(index, 1)
-      this.indexOrShowPage === 'show' ? this.$router.push('/cars') : null
+      this.indexOrShowPage === 'show' ? this.$router.push(`/cars?user_id=${this.loggedInUser.id}`) : null
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -3403,8 +3403,8 @@ class ApplicationController < ActionController::API
     cars = Car.where(user_id: user.id).map { |car| prep_raw_car(car) }
     maintenances_ids = Maintenance.where(car_id: car_ids).map { |maintenance| maintenance.id }
     maintenances = Maintenance.where(car_id: car_ids).map { |maintenance| prep_raw_maintenance(maintenance) }
-    documents_ids = Document.where(documentable_id: car_ids, documentable_type: "Car").map { |document| document.id }
-    documents = Document.where(documentable_id: car_ids, documentable_type: "Car").map { |document| prep_raw_document(document) }
+    documents_ids = Document.where(documentable_id: car_ids, documentable_type: "Car").or(Document.where(documentable_id: maintenances_ids, documentable_type: "Maintenance")).map { |document| document.id }
+    documents = Document.where(documentable_id: car_ids, documentable_type: "Car").or(Document.where(documentable_id: maintenances_ids, documentable_type: "Maintenance")).map { |document| prep_raw_document(document) }
     user = user.admin ? user.slice(:id,:email,:name,:admin) : user.slice(:id,:email,:name)
     user['avatar'] = avatar
     user['car_ids'] = car_ids

--- a/README.md
+++ b/README.md
@@ -6279,18 +6279,21 @@ describe('Admin /users page', () => {
 describe('Admin visiting /cars', () => {
 
   context('No query string', () => {
-    it("Should show admin's two cars", () => {
+    it("Should show all users' cars", () => {
       cy.loginAdmin()
       cy.url().should('match', /http:\/\/localhost:3001\/users\/1/)
       cy.visit('http://localhost:3001/cars')
       cy.url().should('match', /http:\/\/localhost:3001\/cars/)
-      cy.get('section').children('div').should('have.length', 2)
+      cy.get('section').children('div').should('have.length', 6)
       cy.get('article').eq(0).find('h2').should('contain', "Michael's Fiat 500")
       cy.get('article').eq(1).find('h2').should('contain', "Michael's Honda Civic")
+      cy.get('article').eq(2).find('h2').should('contain', "Jim's Hyundai Elantra")
+      cy.get('article').eq(3).find('h2').should('contain', "Jim's Nissan Leaf")
+      cy.get('article').eq(4).find('h2').should('contain', "Pam's Scion Xb")
+      cy.get('article').eq(5).find('h2').should('contain', "Pam's Toyota Camry")
       cy.logoutAdmin()
     })
   })
-
 
   context('?admin=true query string', () => {
     it("Should show all cars", () => {

--- a/README.md
+++ b/README.md
@@ -4351,7 +4351,7 @@ export default {
 <template>
   <article>
     <h2>
-      <NuxtLink :to="`/users/${user.id}`">{{ user.name }}</NuxtLink> 
+      <NuxtLink :to="`/users/${user.id}?user_id=${loggedInUser.id}`">{{ user.name }}</NuxtLink> 
       <NuxtLink :to="`/users/${user.id}/edit`"><font-awesome-icon icon="pencil" /></NuxtLink>
       <a @click.prevent=deleteUser(user.id) href="#"><font-awesome-icon icon="trash" /></a>
     </h2>
@@ -4368,8 +4368,7 @@ import { mapGetters } from 'vuex'
 export default {
   name: 'UserCard',
   computed: { 
-    ...mapGetters(['isAdmin']),
-    ...mapGetters(['indexOrShowPage'])
+    ...mapGetters(['isAdmin', 'indexOrShowPage', 'loggedInUser'])
   },
   props: {
     user: {
@@ -4483,7 +4482,7 @@ export default { middleware: 'currentOrAdmin-showEdit' }
 <template>
   <article>
     <h2>
-      <NuxtLink :to="`/cars/${car.id}`">{{ car.name }}</NuxtLink> 
+      <NuxtLink :to="`/cars/${car.id}?user_id=${loggedInUser.id}`">{{ car.name }}</NuxtLink> 
       <NuxtLink :to="`/cars/${car.id}/edit`"><font-awesome-icon icon="pencil" /></NuxtLink>
       <a @click.prevent=deleteCar(car.id) href="#"><font-awesome-icon icon="trash" /></a>
     </h2>
@@ -4522,8 +4521,7 @@ import { mapGetters } from 'vuex'
 export default {
   name: 'CarCard',
   computed: { 
-    ...mapGetters(['isAdmin']),
-    ...mapGetters(['indexOrShowPage'])
+    ...mapGetters(['isAdmin', 'indexOrShowPage', 'loggedInUser']),
   },
   props: {
     car: {
@@ -4799,7 +4797,7 @@ export default { middleware: 'currentOrAdmin-showEdit' }
 <template>
   <article>
     <h2>
-      <NuxtLink :to="`/maintenances/${maintenance.id}`">{{ maintenance.description }}</NuxtLink> 
+      <NuxtLink :to="`/maintenances/${maintenance.id}?user_id=${loggedInUser.id}`">{{ maintenance.description }}</NuxtLink> 
       <NuxtLink :to="`/maintenances/${maintenance.id}/edit`"><font-awesome-icon icon="pencil" /></NuxtLink>
       <a @click.prevent=deleteMaintenance(maintenance.id) href="#"><font-awesome-icon icon="trash" /></a>
     </h2>
@@ -4829,8 +4827,7 @@ import { mapGetters } from 'vuex'
 export default {
   name: 'MaintenanceCard',
   computed: { 
-    ...mapGetters(['isAdmin']),
-    ...mapGetters(['indexOrShowPage'])
+    ...mapGetters(['isAdmin', 'indexOrShowPage', 'loggedInUser'])
   },
   props: {
     maintenance: {
@@ -5086,7 +5083,7 @@ export default { middleware: 'currentOrAdmin-showEdit' }
 <template>
   <article>
     <h2>
-      <NuxtLink :to="`/documents/${document.id}`">{{ document.name }}</NuxtLink> 
+      <NuxtLink :to="`/documents/${document.id}?user_id=${loggedInUser.id}`">{{ document.name }}</NuxtLink> 
       <NuxtLink :to="`/documents/${document.id}/edit`"><font-awesome-icon icon="pencil" /></NuxtLink>
       <a @click.prevent=deleteDocument(document.id) href="#"><font-awesome-icon icon="trash" /></a>
     </h2>
@@ -5104,8 +5101,7 @@ import { mapGetters } from 'vuex'
 export default {
   name: 'DocumentCard',
   computed: { 
-    ...mapGetters(['isAdmin']),
-    ...mapGetters(['indexOrShowPage'])
+    ...mapGetters(['isAdmin', 'indexOrShowPage', 'loggedInUser'])
   },
   props: {
     document: {

--- a/README.md
+++ b/README.md
@@ -4367,7 +4367,10 @@ export default {
 import { mapGetters } from 'vuex'
 export default {
   name: 'UserCard',
-  computed: { ...mapGetters(['isAdmin']) },
+  computed: { 
+    ...mapGetters(['isAdmin']),
+    ...mapGetters(['indexOrShowPage'])
+  },
   props: {
     user: {
       type: Object,
@@ -4385,7 +4388,8 @@ export default {
     deleteUser: function(id) {
       this.$axios.$delete(`users/${id}`)
       const index = this.users.findIndex((i) => { return i.id === id })
-      this.users.splice(index, 1);
+      this.users.splice(index, 1)
+      this.indexOrShowPage === 'show' ? this.$router.push('/users') : null
     }
   }
 }
@@ -4824,7 +4828,10 @@ export default { middleware: 'currentOrAdmin-showEdit' }
 import { mapGetters } from 'vuex'
 export default {
   name: 'MaintenanceCard',
-  computed: { ...mapGetters(['isAdmin']) },
+  computed: { 
+    ...mapGetters(['isAdmin']),
+    ...mapGetters(['indexOrShowPage'])
+  },
   props: {
     maintenance: {
       type: Object,
@@ -4842,7 +4849,8 @@ export default {
     deleteMaintenance: function(id) {
       this.$axios.$delete(`maintenances/${id}`)
       const index = this.maintenances.findIndex((i) => { return i.id === id })
-      this.maintenances.splice(index, 1);
+      this.maintenances.splice(index, 1)
+      this.indexOrShowPage === 'show' ? this.$router.push('/maintenances') : null
     }
   }
 }
@@ -5095,6 +5103,10 @@ export default { middleware: 'currentOrAdmin-showEdit' }
 import { mapGetters } from 'vuex'
 export default {
   name: 'DocumentCard',
+  computed: { 
+    ...mapGetters(['isAdmin']),
+    ...mapGetters(['indexOrShowPage'])
+  },
   props: {
     document: {
       type: Object,
@@ -5105,7 +5117,6 @@ export default {
       default: () => ([]),
     },
   },
-  computed: { ...mapGetters(['isAdmin']) },
   methods: {
     uploadImage: function() {
       this.image = this.$refs.inputFile.files[0];
@@ -5113,7 +5124,8 @@ export default {
     deleteDocument: function(id) {
       this.$axios.$delete(`documents/${id}`)
       const index = this.documents.findIndex((i) => { return i.id === id })
-      this.documents.splice(index, 1);
+      this.documents.splice(index, 1)
+      this.indexOrShowPage === 'show' ? this.$router.push('/documents') : null
     }
     
   }

--- a/README.md
+++ b/README.md
@@ -4201,6 +4201,7 @@ export default function ({ route, store, redirect }) {
   const actual_user_id = loggedInUser.id
   const isUserRequestingOwnData = requested_user_id === actual_user_id
   const pathWithoutQuery = route.path.split('?')[0]
+  const pathWithAdminQuery = `${pathWithoutQuery}?admin=true`
 
   if (!isAuthenticated) {
     return redirect('/')
@@ -4208,7 +4209,7 @@ export default function ({ route, store, redirect }) {
     const pathWithUserId = `${pathWithoutQuery}?user_id=${loggedInUser.id}`
     return redirect(pathWithUserId)
   } else if (isQueryEmpty) {
-    return redirect(pathWithoutQuery)
+    return redirect(pathWithAdminQuery)
   }
 }
 ~

--- a/README.md
+++ b/README.md
@@ -4517,7 +4517,10 @@ export default { middleware: 'currentOrAdmin-showEdit' }
 import { mapGetters } from 'vuex'
 export default {
   name: 'CarCard',
-  computed: { ...mapGetters(['isAdmin']) },
+  computed: { 
+    ...mapGetters(['isAdmin']),
+    ...mapGetters(['indexOrShowPage'])
+  },
   props: {
     car: {
       type: Object,
@@ -4535,7 +4538,8 @@ export default {
     deleteCar: function(id) {
       this.$axios.$delete(`cars/${id}`)
       const index = this.cars.findIndex((i) => { return i.id === id })
-      this.cars.splice(index, 1);
+      this.cars.splice(index, 1)
+      this.indexOrShowPage === 'show' ? this.$router.push('/cars') : null
     }
   }
 }
@@ -5786,6 +5790,13 @@ export const getters = {
 
   loggedInUser(state) {
     return state.auth.user
+  },
+
+  indexOrShowPage() {
+    const splitUrl = $nuxt.$route.path.split('/')
+    const urlEnd = splitUrl[splitUrl.length-1]
+    const regex = /cars|maintenances|documents/
+    return regex.test(urlEnd) ? 'index' : 'show'
   }
 }
 ~

--- a/README.md
+++ b/README.md
@@ -4185,7 +4185,8 @@ function isEditPage(url) {
 }
 
 function isShowPage(url) {
-  const splitUrl = url.split('/')
+  const urlWithoutQuery = url.split('?')[0]
+  const splitUrl = urlWithoutQuery.split('/')
   return (!isNaN(splitUrl[splitUrl.length-1]) && !isEditPage(url)) ? true : false
 }
 ~

--- a/back/app/controllers/application_controller.rb
+++ b/back/app/controllers/application_controller.rb
@@ -55,8 +55,8 @@ class ApplicationController < ActionController::API
     cars = Car.where(user_id: user.id).map { |car| prep_raw_car(car) }
     maintenances_ids = Maintenance.where(car_id: car_ids).map(&:id)
     maintenances = Maintenance.where(car_id: car_ids).map { |maintenance| prep_raw_maintenance(maintenance) }
-    documents_ids = Document.where(documentable_id: car_ids, documentable_type: 'Car').map(&:id)
-    documents = Document.where(documentable_id: car_ids, documentable_type: 'Car').map do |document|
+    documents_ids = Document.where(documentable_id: car_ids, documentable_type: "Car").or(Document.where(documentable_id: maintenances_ids, documentable_type: "Maintenance")).map { |document| document.id }
+    documents = Document.where(documentable_id: car_ids, documentable_type: "Car").or(Document.where(documentable_id: maintenances_ids, documentable_type: "Maintenance")).map { |document| prep_raw_document(document) }
       prep_raw_document(document)
     end
     user = user.admin ? user.slice(:id, :email, :name, :admin) : user.slice(:id, :email, :name)

--- a/back/app/controllers/application_controller.rb
+++ b/back/app/controllers/application_controller.rb
@@ -57,8 +57,7 @@ class ApplicationController < ActionController::API
     maintenances = Maintenance.where(car_id: car_ids).map { |maintenance| prep_raw_maintenance(maintenance) }
     documents_ids = Document.where(documentable_id: car_ids, documentable_type: "Car").or(Document.where(documentable_id: maintenances_ids, documentable_type: "Maintenance")).map { |document| document.id }
     documents = Document.where(documentable_id: car_ids, documentable_type: "Car").or(Document.where(documentable_id: maintenances_ids, documentable_type: "Maintenance")).map { |document| prep_raw_document(document) }
-      prep_raw_document(document)
-    end
+      
     user = user.admin ? user.slice(:id, :email, :name, :admin) : user.slice(:id, :email, :name)
     user['avatar'] = avatar
     user['car_ids'] = car_ids

--- a/front/components/car/Card.vue
+++ b/front/components/car/Card.vue
@@ -1,7 +1,7 @@
 <template>
   <article>
     <h2>
-      <NuxtLink :to="`/cars/${car.id}`">{{ car.name }}</NuxtLink> 
+      <NuxtLink :to="`/cars/${car.id}?user_id=${loggedInUser.id}`">{{ car.name }}</NuxtLink> 
       <NuxtLink :to="`/cars/${car.id}/edit`"><font-awesome-icon icon="pencil" /></NuxtLink>
       <a @click.prevent=deleteCar(car.id) href="#"><font-awesome-icon icon="trash" /></a>
     </h2>
@@ -39,7 +39,9 @@
 import { mapGetters } from 'vuex'
 export default {
   name: 'CarCard',
-  computed: { ...mapGetters(['isAdmin']) },
+  computed: { 
+    ...mapGetters(['isAdmin', 'indexOrShowPage', 'loggedInUser']),
+  },
   props: {
     car: {
       type: Object,
@@ -55,9 +57,11 @@ export default {
       this.image = this.$refs.inputFile.files[0];
     },
     deleteCar: function(id) {
-      this.$axios.$delete(`cars/${id}`)
-      const index = this.cars.findIndex((i) => { return i.id === id })
-      this.cars.splice(index, 1);
+      console.log(this.cars)
+      // this.$axios.$delete(`cars/${id}`)
+      // const index = this.cars.findIndex((i) => { return i.id === id })
+      // this.cars.splice(index, 1)
+      // this.indexOrShowPage === 'show' ? this.$router.push(`/cars?user_id=${this.loggedInUser.id}`) : null
     }
   }
 }

--- a/front/components/car/Card.vue
+++ b/front/components/car/Card.vue
@@ -57,11 +57,10 @@ export default {
       this.image = this.$refs.inputFile.files[0];
     },
     deleteCar: function(id) {
-      console.log(this.cars)
-      // this.$axios.$delete(`cars/${id}`)
-      // const index = this.cars.findIndex((i) => { return i.id === id })
-      // this.cars.splice(index, 1)
-      // this.indexOrShowPage === 'show' ? this.$router.push(`/cars?user_id=${this.loggedInUser.id}`) : null
+      this.$axios.$delete(`cars/${id}`)
+      const index = this.cars.findIndex((i) => { return i.id === id })
+      this.cars.splice(index, 1)
+      this.indexOrShowPage === 'show' ? this.$router.push(`/cars?user_id=${this.loggedInUser.id}`) : null
     }
   }
 }

--- a/front/components/document/Card.vue
+++ b/front/components/document/Card.vue
@@ -1,7 +1,7 @@
 <template>
   <article>
     <h2>
-      <NuxtLink :to="`/documents/${document.id}`">{{ document.name }}</NuxtLink> 
+      <NuxtLink :to="`/documents/${document.id}?user_id=${loggedInUser.id}`">{{ document.name }}</NuxtLink> 
       <NuxtLink :to="`/documents/${document.id}/edit`"><font-awesome-icon icon="pencil" /></NuxtLink>
       <a @click.prevent=deleteDocument(document.id) href="#"><font-awesome-icon icon="trash" /></a>
     </h2>
@@ -18,6 +18,9 @@
 import { mapGetters } from 'vuex'
 export default {
   name: 'DocumentCard',
+  computed: { 
+    ...mapGetters(['isAdmin', 'indexOrShowPage', 'loggedInUser'])
+  },
   props: {
     document: {
       type: Object,
@@ -28,7 +31,6 @@ export default {
       default: () => ([]),
     },
   },
-  computed: { ...mapGetters(['isAdmin']) },
   methods: {
     uploadImage: function() {
       this.image = this.$refs.inputFile.files[0];
@@ -36,7 +38,8 @@ export default {
     deleteDocument: function(id) {
       this.$axios.$delete(`documents/${id}`)
       const index = this.documents.findIndex((i) => { return i.id === id })
-      this.documents.splice(index, 1);
+      this.documents.splice(index, 1)
+      this.indexOrShowPage === 'show' ? this.$router.push(`/documents?user_id=${this.loggedInUser.id}`) : null
     }
     
   }

--- a/front/components/document/Card.vue
+++ b/front/components/document/Card.vue
@@ -39,7 +39,7 @@ export default {
       this.$axios.$delete(`documents/${id}`)
       const index = this.documents.findIndex((i) => { return i.id === id })
       this.documents.splice(index, 1)
-      this.indexOrShowPage === 'show' ? this.$router.push(`/documents?user_id=${this.loggedInUser.id}`) : null
+      this.indexOrShowPage === 'show' ? this.$router.push('/documents') : null
     }
     
   }

--- a/front/components/maintenance/Card.vue
+++ b/front/components/maintenance/Card.vue
@@ -1,7 +1,7 @@
 <template>
   <article>
     <h2>
-      <NuxtLink :to="`/maintenances/${maintenance.id}`">{{ maintenance.description }}</NuxtLink> 
+      <NuxtLink :to="`/maintenances/${maintenance.id}?user_id=${loggedInUser.id}`">{{ maintenance.description }}</NuxtLink> 
       <NuxtLink :to="`/maintenances/${maintenance.id}/edit`"><font-awesome-icon icon="pencil" /></NuxtLink>
       <a @click.prevent=deleteMaintenance(maintenance.id) href="#"><font-awesome-icon icon="trash" /></a>
     </h2>
@@ -30,7 +30,9 @@
 import { mapGetters } from 'vuex'
 export default {
   name: 'MaintenanceCard',
-  computed: { ...mapGetters(['isAdmin']) },
+  computed: { 
+    ...mapGetters(['isAdmin', 'indexOrShowPage', 'loggedInUser'])
+  },
   props: {
     maintenance: {
       type: Object,
@@ -48,7 +50,8 @@ export default {
     deleteMaintenance: function(id) {
       this.$axios.$delete(`maintenances/${id}`)
       const index = this.maintenances.findIndex((i) => { return i.id === id })
-      this.maintenances.splice(index, 1);
+      this.maintenances.splice(index, 1)
+      this.indexOrShowPage === 'show' ? this.$router.push(`/maintenances?user_id=${this.loggedInUser.id}`) : null
     }
   }
 }

--- a/front/components/maintenance/Card.vue
+++ b/front/components/maintenance/Card.vue
@@ -51,7 +51,7 @@ export default {
       this.$axios.$delete(`maintenances/${id}`)
       const index = this.maintenances.findIndex((i) => { return i.id === id })
       this.maintenances.splice(index, 1)
-      this.indexOrShowPage === 'show' ? this.$router.push(`/maintenances?user_id=${this.loggedInUser.id}`) : null
+      this.indexOrShowPage === 'show' ? this.$router.push('/maintenances') : null
     }
   }
 }

--- a/front/components/user/Card.vue
+++ b/front/components/user/Card.vue
@@ -1,7 +1,7 @@
 <template>
   <article>
     <h2>
-      <NuxtLink :to="`/users/${user.id}`">{{ user.name }}</NuxtLink> 
+      <NuxtLink :to="`/users/${user.id}?user_id=${loggedInUser.id}`">{{ user.name }}</NuxtLink> 
       <NuxtLink :to="`/users/${user.id}/edit`"><font-awesome-icon icon="pencil" /></NuxtLink>
       <a @click.prevent=deleteUser(user.id) href="#"><font-awesome-icon icon="trash" /></a>
     </h2>
@@ -17,7 +17,9 @@
 import { mapGetters } from 'vuex'
 export default {
   name: 'UserCard',
-  computed: { ...mapGetters(['isAdmin']) },
+  computed: { 
+    ...mapGetters(['isAdmin', 'indexOrShowPage', 'loggedInUser'])
+  },
   props: {
     user: {
       type: Object,
@@ -35,7 +37,8 @@ export default {
     deleteUser: function(id) {
       this.$axios.$delete(`users/${id}`)
       const index = this.users.findIndex((i) => { return i.id === id })
-      this.users.splice(index, 1);
+      this.users.splice(index, 1)
+      this.indexOrShowPage === 'show' ? this.$router.push('/users') : null
     }
   }
 }

--- a/front/cypress/e2e/admin.cy.js
+++ b/front/cypress/e2e/admin.cy.js
@@ -115,18 +115,21 @@ describe('Admin /users page', () => {
 describe('Admin visiting /cars', () => {
 
   context('No query string', () => {
-    it("Should show admin's two cars", () => {
+    it("Should show all users' cars", () => {
       cy.loginAdmin()
       cy.url().should('match', /http:\/\/localhost:3001\/users\/1/)
       cy.visit('http://localhost:3001/cars')
       cy.url().should('match', /http:\/\/localhost:3001\/cars/)
-      cy.get('section').children('div').should('have.length', 2)
+      cy.get('section').children('div').should('have.length', 6)
       cy.get('article').eq(0).find('h2').should('contain', "Michael's Fiat 500")
       cy.get('article').eq(1).find('h2').should('contain', "Michael's Honda Civic")
+      cy.get('article').eq(2).find('h2').should('contain', "Jim's Hyundai Elantra")
+      cy.get('article').eq(3).find('h2').should('contain', "Jim's Nissan Leaf")
+      cy.get('article').eq(4).find('h2').should('contain', "Pam's Scion Xb")
+      cy.get('article').eq(5).find('h2').should('contain', "Pam's Toyota Camry")
       cy.logoutAdmin()
     })
   })
-
 
   context('?admin=true query string', () => {
     it("Should show all cars", () => {

--- a/front/middleware/currentOrAdmin-index.js
+++ b/front/middleware/currentOrAdmin-index.js
@@ -1,17 +1,18 @@
 export default function ({ route, store, redirect }) {
-  const { isAdmin, loggedInUser } = store.getters
+  const { isAdmin, loggedInUser, isAuthenticated } = store.getters
   const query = route.query
-  const isAdminRequest = query['admin'] ? true : false
-  const isUserIdRequest = query['user_id'] ? true : false
   const isQueryEmpty = Object.keys(query).length === 0 ? true : false
-  const userIdRequestButNotAdmin = isUserIdRequest && !isAdmin
   const requested_user_id = parseInt(query['user_id'])
   const actual_user_id = loggedInUser.id
-  const allowedAccess = requested_user_id === actual_user_id ? true : false
+  const isUserRequestingOwnData = requested_user_id === actual_user_id
+  const pathWithoutQuery = route.path.split('?')[0]
 
-  if ((isAdminRequest || isQueryEmpty) && !isAdmin) {
+  if (!isAuthenticated) {
     return redirect('/')
-  } else if (userIdRequestButNotAdmin && !allowedAccess) {
-    return redirect('/cars?user_id=' + loggedInUser.id)
+  } else if (!isAdmin && !isQueryEmpty && !isUserRequestingOwnData) {
+    const pathWithUserId = `${pathWithoutQuery}?user_id=${loggedInUser.id}`
+    return redirect(pathWithUserId)
+  } else if (isQueryEmpty) {
+    return redirect(pathWithoutQuery)
   }
 }

--- a/front/middleware/currentOrAdmin-index.js
+++ b/front/middleware/currentOrAdmin-index.js
@@ -6,6 +6,7 @@ export default function ({ route, store, redirect }) {
   const actual_user_id = loggedInUser.id
   const isUserRequestingOwnData = requested_user_id === actual_user_id
   const pathWithoutQuery = route.path.split('?')[0]
+  const pathWithAdminQuery = `${pathWithoutQuery}?admin=true`
 
   if (!isAuthenticated) {
     return redirect('/')
@@ -13,6 +14,6 @@ export default function ({ route, store, redirect }) {
     const pathWithUserId = `${pathWithoutQuery}?user_id=${loggedInUser.id}`
     return redirect(pathWithUserId)
   } else if (isQueryEmpty) {
-    return redirect(pathWithoutQuery)
+    return redirect(pathWithAdminQuery)
   }
 }

--- a/front/middleware/currentOrAdmin-showEdit.js
+++ b/front/middleware/currentOrAdmin-showEdit.js
@@ -49,6 +49,7 @@ function isEditPage(url) {
 }
 
 function isShowPage(url) {
-  const splitUrl = url.split('/')
+  const urlWithoutQuery = url.split('?')[0]
+  const splitUrl = urlWithoutQuery.split('/')
   return (!isNaN(splitUrl[splitUrl.length-1]) && !isEditPage(url)) ? true : false
 }

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -5909,9 +5909,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001596",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001596.tgz",
-      "integrity": "sha512-zpkZ+kEr6We7w63ORkoJ2pOfBwBkY/bJrG/UZ90qNb45Isblu8wzDgevEOrRL1r9dWayHjYiiyCMEXPn4DweGQ==",
+      "version": "1.0.30001597",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001597.tgz",
+      "integrity": "sha512-7LjJvmQU6Sj7bL0j5b5WY/3n7utXUJvAe1lxhsHDbLmwX9mdL86Yjtr+5SRCyf8qME4M7pU2hswj0FpyBVCv9w==",
       "funding": [
         {
           "type": "opencollective",
@@ -17472,15 +17472,15 @@
       }
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.14.tgz",
-      "integrity": "sha512-VnXFiIW8yNn9kIHN88xvZ4yOWchftKDsRJ8fEPacX/wl1lOvBrhsJ/OeJCXq7B0AaijRuqgzSKalJoPk+D8MPg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.15.tgz",
+      "integrity": "sha512-oV0jmFtUky6CXfkqehVvBP/LSWJ2sy4vWMioiENyJLePrBO/yKyV9OyJySfAKosh+RYkIl5zJCNZ8/4JncrpdA==",
       "dependencies": {
-        "available-typed-arrays": "^1.0.6",
-        "call-bind": "^1.0.5",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.7",
         "for-each": "^0.3.3",
         "gopd": "^1.0.1",
-        "has-tostringtag": "^1.0.1"
+        "has-tostringtag": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -8990,9 +8990,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.1.tgz",
-      "integrity": "sha512-1/th4MHjnwncwXsIW6QMzlvYL9kG5e/CpVvLRZe4XPa8TOUNbCELqmvhDmnkNsAjwaG4+I8gJJL0JBvTTLO9qA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
       "dependencies": {
         "function-bind": "^1.1.2"
       },

--- a/front/store/index.js
+++ b/front/store/index.js
@@ -13,5 +13,12 @@ export const getters = {
 
   loggedInUser(state) {
     return state.auth.user
+  },
+
+  indexOrShowPage() {
+    const splitUrl = $nuxt.$route.path.split('/')
+    const urlEnd = splitUrl[splitUrl.length-1]
+    const regex = /cars|maintenances|documents/
+    return regex.test(urlEnd) ? 'index' : 'show'
   }
 }

--- a/install.sh
+++ b/install.sh
@@ -4098,7 +4098,10 @@ cat <<'EOF' | puravida components/car/Card.vue ~
 import { mapGetters } from 'vuex'
 export default {
   name: 'CarCard',
-  computed: { ...mapGetters(['isAdmin']) },
+  computed: { 
+    ...mapGetters(['isAdmin']),
+    ...mapGetters(['indexOrShowPage'])
+  },
   props: {
     car: {
       type: Object,
@@ -4116,7 +4119,8 @@ export default {
     deleteCar: function(id) {
       this.$axios.$delete(`cars/${id}`)
       const index = this.cars.findIndex((i) => { return i.id === id })
-      this.cars.splice(index, 1);
+      this.cars.splice(index, 1)
+      this.indexOrShowPage === 'show' ? this.$router.push('/cars') : null
     }
   }
 }
@@ -5346,6 +5350,13 @@ export const getters = {
 
   loggedInUser(state) {
     return state.auth.user
+  },
+
+  indexOrShowPage() {
+    const splitUrl = $nuxt.$route.path.split('/')
+    const urlEnd = splitUrl[splitUrl.length-1]
+    const regex = /cars|maintenances|documents/
+    return regex.test(urlEnd) ? 'index' : 'show'
   }
 }
 ~

--- a/install.sh
+++ b/install.sh
@@ -3951,7 +3951,10 @@ cat <<'EOF' | puravida components/user/Card.vue ~
 import { mapGetters } from 'vuex'
 export default {
   name: 'UserCard',
-  computed: { ...mapGetters(['isAdmin']) },
+  computed: { 
+    ...mapGetters(['isAdmin']),
+    ...mapGetters(['indexOrShowPage'])
+  },
   props: {
     user: {
       type: Object,
@@ -3969,7 +3972,8 @@ export default {
     deleteUser: function(id) {
       this.$axios.$delete(`users/${id}`)
       const index = this.users.findIndex((i) => { return i.id === id })
-      this.users.splice(index, 1);
+      this.users.splice(index, 1)
+      this.indexOrShowPage === 'show' ? this.$router.push('/users') : null
     }
   }
 }
@@ -4403,7 +4407,10 @@ cat <<'EOF' | puravida components/maintenance/Card.vue ~
 import { mapGetters } from 'vuex'
 export default {
   name: 'MaintenanceCard',
-  computed: { ...mapGetters(['isAdmin']) },
+  computed: { 
+    ...mapGetters(['isAdmin']),
+    ...mapGetters(['indexOrShowPage'])
+  },
   props: {
     maintenance: {
       type: Object,
@@ -4421,7 +4428,8 @@ export default {
     deleteMaintenance: function(id) {
       this.$axios.$delete(`maintenances/${id}`)
       const index = this.maintenances.findIndex((i) => { return i.id === id })
-      this.maintenances.splice(index, 1);
+      this.maintenances.splice(index, 1)
+      this.indexOrShowPage === 'show' ? this.$router.push('/maintenances') : null
     }
   }
 }
@@ -4668,6 +4676,10 @@ cat <<'EOF' | puravida components/document/Card.vue ~
 import { mapGetters } from 'vuex'
 export default {
   name: 'DocumentCard',
+  computed: { 
+    ...mapGetters(['isAdmin']),
+    ...mapGetters(['indexOrShowPage'])
+  },
   props: {
     document: {
       type: Object,
@@ -4678,7 +4690,6 @@ export default {
       default: () => ([]),
     },
   },
-  computed: { ...mapGetters(['isAdmin']) },
   methods: {
     uploadImage: function() {
       this.image = this.$refs.inputFile.files[0];
@@ -4686,7 +4697,8 @@ export default {
     deleteDocument: function(id) {
       this.$axios.$delete(`documents/${id}`)
       const index = this.documents.findIndex((i) => { return i.id === id })
-      this.documents.splice(index, 1);
+      this.documents.splice(index, 1)
+      this.indexOrShowPage === 'show' ? this.$router.push('/documents') : null
     }
     
   }

--- a/install.sh
+++ b/install.sh
@@ -3776,7 +3776,8 @@ function isEditPage(url) {
 }
 
 function isShowPage(url) {
-  const splitUrl = url.split('/')
+  const urlWithoutQuery = url.split('?')[0]
+  const splitUrl = urlWithoutQuery.split('/')
   return (!isNaN(splitUrl[splitUrl.length-1]) && !isEditPage(url)) ? true : false
 }
 ~

--- a/install.sh
+++ b/install.sh
@@ -3012,8 +3012,8 @@ class ApplicationController < ActionController::API
     cars = Car.where(user_id: user.id).map { |car| prep_raw_car(car) }
     maintenances_ids = Maintenance.where(car_id: car_ids).map { |maintenance| maintenance.id }
     maintenances = Maintenance.where(car_id: car_ids).map { |maintenance| prep_raw_maintenance(maintenance) }
-    documents_ids = Document.where(documentable_id: car_ids, documentable_type: "Car").map { |document| document.id }
-    documents = Document.where(documentable_id: car_ids, documentable_type: "Car").map { |document| prep_raw_document(document) }
+    documents_ids = Document.where(documentable_id: car_ids, documentable_type: "Car").or(Document.where(documentable_id: maintenances_ids, documentable_type: "Maintenance")).map { |document| document.id }
+    documents = Document.where(documentable_id: car_ids, documentable_type: "Car").or(Document.where(documentable_id: maintenances_ids, documentable_type: "Maintenance")).map { |document| prep_raw_document(document) }
     user = user.admin ? user.slice(:id,:email,:name,:admin) : user.slice(:id,:email,:name)
     user['avatar'] = avatar
     user['car_ids'] = car_ids

--- a/install.sh
+++ b/install.sh
@@ -5810,18 +5810,21 @@ describe('Admin /users page', () => {
 describe('Admin visiting /cars', () => {
 
   context('No query string', () => {
-    it("Should show admin's two cars", () => {
+    it("Should show all users' cars", () => {
       cy.loginAdmin()
       cy.url().should('match', /http:\/\/localhost:3001\/users\/1/)
       cy.visit('http://localhost:3001/cars')
       cy.url().should('match', /http:\/\/localhost:3001\/cars/)
-      cy.get('section').children('div').should('have.length', 2)
+      cy.get('section').children('div').should('have.length', 6)
       cy.get('article').eq(0).find('h2').should('contain', "Michael's Fiat 500")
       cy.get('article').eq(1).find('h2').should('contain', "Michael's Honda Civic")
+      cy.get('article').eq(2).find('h2').should('contain', "Jim's Hyundai Elantra")
+      cy.get('article').eq(3).find('h2').should('contain', "Jim's Nissan Leaf")
+      cy.get('article').eq(4).find('h2').should('contain', "Pam's Scion Xb")
+      cy.get('article').eq(5).find('h2').should('contain', "Pam's Toyota Camry")
       cy.logoutAdmin()
     })
   })
-
 
   context('?admin=true query string', () => {
     it("Should show all cars", () => {

--- a/install.sh
+++ b/install.sh
@@ -3791,6 +3791,7 @@ export default function ({ route, store, redirect }) {
   const actual_user_id = loggedInUser.id
   const isUserRequestingOwnData = requested_user_id === actual_user_id
   const pathWithoutQuery = route.path.split('?')[0]
+  const pathWithAdminQuery = `${pathWithoutQuery}?admin=true`
 
   if (!isAuthenticated) {
     return redirect('/')
@@ -3798,7 +3799,7 @@ export default function ({ route, store, redirect }) {
     const pathWithUserId = `${pathWithoutQuery}?user_id=${loggedInUser.id}`
     return redirect(pathWithUserId)
   } else if (isQueryEmpty) {
-    return redirect(pathWithoutQuery)
+    return redirect(pathWithAdminQuery)
   }
 }
 ~

--- a/install.sh
+++ b/install.sh
@@ -3935,7 +3935,7 @@ cat <<'EOF' | puravida components/user/Card.vue ~
 <template>
   <article>
     <h2>
-      <NuxtLink :to="`/users/${user.id}`">{{ user.name }}</NuxtLink> 
+      <NuxtLink :to="`/users/${user.id}?user_id=${loggedInUser.id}`">{{ user.name }}</NuxtLink> 
       <NuxtLink :to="`/users/${user.id}/edit`"><font-awesome-icon icon="pencil" /></NuxtLink>
       <a @click.prevent=deleteUser(user.id) href="#"><font-awesome-icon icon="trash" /></a>
     </h2>
@@ -3952,8 +3952,7 @@ import { mapGetters } from 'vuex'
 export default {
   name: 'UserCard',
   computed: { 
-    ...mapGetters(['isAdmin']),
-    ...mapGetters(['indexOrShowPage'])
+    ...mapGetters(['isAdmin', 'indexOrShowPage', 'loggedInUser'])
   },
   props: {
     user: {
@@ -4064,7 +4063,7 @@ cat <<'EOF' | puravida components/car/Card.vue ~
 <template>
   <article>
     <h2>
-      <NuxtLink :to="`/cars/${car.id}`">{{ car.name }}</NuxtLink> 
+      <NuxtLink :to="`/cars/${car.id}?user_id=${loggedInUser.id}`">{{ car.name }}</NuxtLink> 
       <NuxtLink :to="`/cars/${car.id}/edit`"><font-awesome-icon icon="pencil" /></NuxtLink>
       <a @click.prevent=deleteCar(car.id) href="#"><font-awesome-icon icon="trash" /></a>
     </h2>
@@ -4103,8 +4102,7 @@ import { mapGetters } from 'vuex'
 export default {
   name: 'CarCard',
   computed: { 
-    ...mapGetters(['isAdmin']),
-    ...mapGetters(['indexOrShowPage'])
+    ...mapGetters(['isAdmin', 'indexOrShowPage', 'loggedInUser']),
   },
   props: {
     car: {
@@ -4378,7 +4376,7 @@ cat <<'EOF' | puravida components/maintenance/Card.vue ~
 <template>
   <article>
     <h2>
-      <NuxtLink :to="`/maintenances/${maintenance.id}`">{{ maintenance.description }}</NuxtLink> 
+      <NuxtLink :to="`/maintenances/${maintenance.id}?user_id=${loggedInUser.id}`">{{ maintenance.description }}</NuxtLink> 
       <NuxtLink :to="`/maintenances/${maintenance.id}/edit`"><font-awesome-icon icon="pencil" /></NuxtLink>
       <a @click.prevent=deleteMaintenance(maintenance.id) href="#"><font-awesome-icon icon="trash" /></a>
     </h2>
@@ -4408,8 +4406,7 @@ import { mapGetters } from 'vuex'
 export default {
   name: 'MaintenanceCard',
   computed: { 
-    ...mapGetters(['isAdmin']),
-    ...mapGetters(['indexOrShowPage'])
+    ...mapGetters(['isAdmin', 'indexOrShowPage', 'loggedInUser'])
   },
   props: {
     maintenance: {
@@ -4659,7 +4656,7 @@ cat <<'EOF' | puravida components/document/Card.vue ~
 <template>
   <article>
     <h2>
-      <NuxtLink :to="`/documents/${document.id}`">{{ document.name }}</NuxtLink> 
+      <NuxtLink :to="`/documents/${document.id}?user_id=${loggedInUser.id}`">{{ document.name }}</NuxtLink> 
       <NuxtLink :to="`/documents/${document.id}/edit`"><font-awesome-icon icon="pencil" /></NuxtLink>
       <a @click.prevent=deleteDocument(document.id) href="#"><font-awesome-icon icon="trash" /></a>
     </h2>
@@ -4677,8 +4674,7 @@ import { mapGetters } from 'vuex'
 export default {
   name: 'DocumentCard',
   computed: { 
-    ...mapGetters(['isAdmin']),
-    ...mapGetters(['indexOrShowPage'])
+    ...mapGetters(['isAdmin', 'indexOrShowPage', 'loggedInUser'])
   },
   props: {
     document: {

--- a/install.sh
+++ b/install.sh
@@ -3784,20 +3784,21 @@ function isShowPage(url) {
 EOF
 cat <<'EOF' | puravida middleware/currentOrAdmin-index.js ~
 export default function ({ route, store, redirect }) {
-  const { isAdmin, loggedInUser } = store.getters
+  const { isAdmin, loggedInUser, isAuthenticated } = store.getters
   const query = route.query
-  const isAdminRequest = query['admin'] ? true : false
-  const isUserIdRequest = query['user_id'] ? true : false
   const isQueryEmpty = Object.keys(query).length === 0 ? true : false
-  const userIdRequestButNotAdmin = isUserIdRequest && !isAdmin
   const requested_user_id = parseInt(query['user_id'])
   const actual_user_id = loggedInUser.id
-  const allowedAccess = requested_user_id === actual_user_id ? true : false
+  const isUserRequestingOwnData = requested_user_id === actual_user_id
+  const pathWithoutQuery = route.path.split('?')[0]
 
-  if ((isAdminRequest || isQueryEmpty) && !isAdmin) {
+  if (!isAuthenticated) {
     return redirect('/')
-  } else if (userIdRequestButNotAdmin && !allowedAccess) {
-    return redirect('/cars?user_id=' + loggedInUser.id)
+  } else if (!isAdmin && !isQueryEmpty && !isUserRequestingOwnData) {
+    const pathWithUserId = `${pathWithoutQuery}?user_id=${loggedInUser.id}`
+    return redirect(pathWithUserId)
+  } else if (isQueryEmpty) {
+    return redirect(pathWithoutQuery)
   }
 }
 ~
@@ -4123,7 +4124,7 @@ export default {
       this.$axios.$delete(`cars/${id}`)
       const index = this.cars.findIndex((i) => { return i.id === id })
       this.cars.splice(index, 1)
-      this.indexOrShowPage === 'show' ? this.$router.push('/cars') : null
+      this.indexOrShowPage === 'show' ? this.$router.push(`/cars?user_id=${this.loggedInUser.id}`) : null
     }
   }
 }


### PR DESCRIPTION
- Fixes a bug on the show page (of cars/maintenances/documents) where if you deleted the item, you weren't redirected back to the index page.
- Fixes permissions bug where if you were an admin and went to /cars (with no query string) it only showed your cars, but now it shows all cars.