### PR TITLE
Exceptions Fun

### DIFF
--- a/back/app/controllers/application_controller.rb
+++ b/back/app/controllers/application_controller.rb
@@ -3,7 +3,7 @@
 class ApplicationController < ActionController::API
   SECRET_KEY_BASE = Rails.application.secret_key_base
   before_action :require_login
-  # rescue_from Exception, with: :response_internal_server_error
+  rescue_from Exception, with: :response_internal_server_error
 
   def require_login
     response_unauthorized if current_user_raw.blank?

--- a/back/app/controllers/application_controller.rb
+++ b/back/app/controllers/application_controller.rb
@@ -3,7 +3,7 @@
 class ApplicationController < ActionController::API
   SECRET_KEY_BASE = Rails.application.secret_key_base
   before_action :require_login
-  rescue_from Exception, with: :response_internal_server_error
+  # rescue_from Exception, with: :response_internal_server_error
 
   def require_login
     response_unauthorized if current_user_raw.blank?

--- a/back/app/controllers/cars_controller.rb
+++ b/back/app/controllers/cars_controller.rb
@@ -15,7 +15,7 @@ class CarsController < ApplicationController
 
   # GET /cars/1
   def show
-    car = Car.find(params[:id])
+    car = Car.finds(params[:id])
     render json: prep_raw_car(car)
 
   rescue ActiveRecord::RecordNotFound => e

--- a/back/app/controllers/cars_controller.rb
+++ b/back/app/controllers/cars_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class CarsController < ApplicationController
-  before_action :set_car, only: %i[show update destroy]
+  before_action :set_car, only: %i[update destroy]
 
   # GET /cars
   def index
@@ -15,7 +15,11 @@ class CarsController < ApplicationController
 
   # GET /cars/1
   def show
-    render json: prep_raw_car(@car)
+    car = Car.find(params[:id])
+    render json: prep_raw_car(car)
+
+  rescue ActiveRecord::RecordNotFound => e
+    render status: :not_found, json: { errors: e.message }
   end
 
   # POST /cars

--- a/back/app/controllers/cars_controller.rb
+++ b/back/app/controllers/cars_controller.rb
@@ -15,7 +15,7 @@ class CarsController < ApplicationController
 
   # GET /cars/1
   def show
-    car = Car.finds(params[:id])
+    car = Car.find(params[:id])
     render json: prep_raw_car(car)
 
   rescue ActiveRecord::RecordNotFound => e

--- a/back/spec/requests/cars_spec.rb
+++ b/back/spec/requests/cars_spec.rb
@@ -127,6 +127,17 @@ RSpec.describe '/cars', type: :request do
       expect(response).to be_successful
     end
 
+    context 'exception handling' do
+      it 'renders a error message if car cannot be found' do
+        car = cars(:fiat)
+        bad_id = car.id + 1
+        get "/cars/#{bad_id}", headers: valid_headers
+
+        expect(response).to have_http_status(:not_found)
+        expect(JSON.parse(response.body)["errors"]).to match(/Couldn't find Car/)
+      end
+    end
+
     it 'gets correct car properties' do
       car = cars(:fiat)
       get car_url(car), headers: valid_headers


### PR DESCRIPTION
Catching all exceptions isn't considered best practice, but why? TLDR avoid rescuing from the top level `Exception` and instead use `StandardError`. Catching all exceptions makes it very difficult to debug when issues come up and doesn't provide a great user experience. It's better to know what specific exceptions are being raised so you can handle them.
Good resources
 - https://www.honeybadger.io/blog/a-beginner-s-guide-to-exceptions-in-ruby/
 - https://www.honeybadger.io/blog/ruby-exception-vs-standarderror-whats-the-difference/
## How to Follow Along Locally
- You can checkout each commit by copying it's SHA
  - For example, `git checkout 344ad696c1d36aee93116251d4ac001528b5cf70`
![image](https://github.com/mark-mcdermott/rux-drivetracks/assets/91904567/fb28bea9-1984-4787-85cf-ee90429ecf3f)


## Walkthrough
Walking through this commit by commit will show how they can cause headaches

- First we intentionally add a failing spec, but the failure isn't what we expect (a 500? 🤔 )
![image](https://github.com/mark-mcdermott/rux-drivetracks/assets/91904567/1a481648-73a6-4dec-9455-6ca34bfb7ed8)

- Then we comment out the catch all exception and run the spec again `bundle exec spec/requests/cars_spec.rb`. Now we've exposed the exception that we need to handle.
![image](https://github.com/mark-mcdermott/rux-drivetracks/assets/91904567/9dc4f39b-4522-45b1-bf95-c1aedd89f764)

- Let's fix it. We avoid using the `before_action` callback and load the car object in the show action so we can rescue appropriately. Now our specs are back to 🟢 

- Now lets show how catching all can muddy the waters. We comment it back in and then purposely fat finger the find method as finds. Run the specs and it's a rabbit hole.
![image](https://github.com/mark-mcdermott/rux-drivetracks/assets/91904567/6fc51f48-c751-4eb7-aece-be45c3432219)

- Comment out the catch all so the exceptions can bubble up. Now running the specs gives you the issue, you mean `find` not `finds`
![image](https://github.com/mark-mcdermott/rux-drivetracks/assets/91904567/2742d2eb-7553-4218-ab70-f77a317100d7)

- Easy fix






