### PR TITLE
Add currency formatting to cost fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -4029,8 +4029,15 @@ document.attachment.attach(io: URI.open("#{Rails.root}/app/assets/images/documen
 // Pico overrides 
 // $primary-500: #e91e63;
 
-h1 {
-  margin: 4rem 0 0
+.container {
+  h1 {
+    margin: 4rem 0
+  }
+  &.home {
+    h1 {
+      margin: 4rem 0 0
+    }
+  }
 }
 
 .subtitle {
@@ -5112,7 +5119,6 @@ export default {
     this.editOrNew = $nuxt.$route.path.split('/')[$nuxt.$route.path.split('/').length-1]
     if ($nuxt.$route.path.split('/')[$nuxt.$route.path.split('/').length-1]=='edit') {
       const maintenance = await this.$axios.$get(`maintenances/${this.$route.params.id}`)
-      console.log(maintenance)
       this.date = maintenance.date
       this.description = maintenance.description,
       this.vendor = maintenance.vendor
@@ -5442,7 +5448,6 @@ export default {
       this.cars = user.cars
       this.maintenances = user.maintenances
       this.documents = user.documents
-      console.log(this.maintenances)
     },
     createDocument: function() {
       const params = {
@@ -5453,8 +5458,6 @@ export default {
         'documentable_type': this.carOrMaintenance,
         'documentable_id': parseInt(this.documentableId)
       }
-      console.log("params")
-      console.log(params)
       let payload = new FormData()
       Object.entries(params).forEach(
         ([key, value]) => payload.append(key, value)
@@ -5798,7 +5801,7 @@ html, body
 - `puravida pages/index.vue ~`
 ```
 <template>
-  <main class="container">
+  <main class="home container">
     <h1>Drivetracks</h1>
     <p class="subtitle">Cloud Car Document Storage</p>
     <img class="challenger" :src="require(`@/assets/images/challenger.png`)" />

--- a/README.md
+++ b/README.md
@@ -1478,7 +1478,7 @@ class ApplicationController < ActionController::API
     ActionController::Base.helpers.number_to_currency(amount)
   end
 
-  def currency_to_number currency
+  def currency_to_number(currency)
     currency.to_s.gsub(/[$,]/,'').to_f
   end
   
@@ -2803,7 +2803,7 @@ class ApplicationController < ActionController::API
     ActionController::Base.helpers.number_to_currency(amount)
   end
 
-  def currency_to_number currency
+  def currency_to_number(currency)
     currency.to_s.gsub(/[$,]/,'').to_f
   end
   
@@ -3477,7 +3477,7 @@ class ApplicationController < ActionController::API
     ActionController::Base.helpers.number_to_currency(amount)
   end
 
-  def currency_to_number currency
+  def currency_to_number(currency)
     currency.to_s.gsub(/[$,]/,'').to_f
   end
   

--- a/README.md
+++ b/README.md
@@ -4515,30 +4515,46 @@ export default { middleware: 'currentOrAdmin-showEdit' }
 <template>
   <input 
     v-bind:value="value"
-    v-on:input="$emit('input', updateCurrencyStr($event.target.value))"
+    v-on:keydown="discardIllegalEntries($event)"
+    v-on:input="$emit('input', updateCurrencyStr($event))"
+    ref="input"
   />
 </template>
 <script>
+  import { ref } from 'vue'
   export default {
     props: ['value'],
+    setup() {
+      const input = ref(null)
+      return {
+        input
+      }
+    },
     methods: {
-      discardIllegalKeys(evt) {
-        if (!this.isNumKey(evt) && !this.isArrowBackspaceOrDeleteKey(evt)) {
+      discardIllegalEntries(evt) {
+        if (this.isIllegalEntry(evt)) {
           evt.preventDefault()
         }
       },
 
-      // TODO - add a check for command + a
-      isArrowBackspaceOrDeleteKey(evt) {
+      isIllegalEntry(evt) {
+        if (evt.altKey || evt.ctrlKey || evt.metaKey) return false  // we don't care what's pressed if alt, ctrl or command are also held down
         const keyCode = evt.keyCode
-        const isDelete = keyCode === 8
-        const isBackspace = keyCode === 46
-        const isArrow = keyCode > 36 && keyCode < 41
-        return (isDelete || isBackspace || isArrow) ? true : false
+        const is58To90 = keyCode > 57 && keyCode < 91               // 58-90 are punctuation, math symbols and letters
+        const is106To111 = keyCode > 105 && keyCode < 112           // 106-111 are math operation symbols
+        const is160 = keyCode === 160                               // 160 is ^ symbol
+        const is163To165 = keyCode > 162 && keyCode < 166           // 163-165 are currency symbols
+        const is169To173 = keyCode > 168 && keyCode < 174           // 169-173 are copyright, trademark, registered, section, dash
+        const is186To223 = keyCode > 185 && keyCode < 224           // 186-223 are punctuation, symbols, math symbols
+        const is226 = keyCode === 226                               // 226 is < symbol
+        const isShiftPlusNumber = evt.shiftKey && this.isNumber(keyCode)
+        const illegalEntries = [is58To90, is106To111, is160, is163To165, is169To173, is186To223, is226, isShiftPlusNumber]
+        const isEntryIllegal = illegalEntries.some(Boolean)         // are any vals in array truthy, https://www.30secondsofcode.org/js/s/check-array-values-are-truthy/#check-if-all-values-in-an-array-are-truthy
+        return isEntryIllegal
       },
 
-      isNumKey(evt) {
-        return evt.key.match(/[0-9]/) ? true : false
+      isNumber(keyCode) {
+        return keyCode > 47 && keyCode < 58 || keyCode > 95 && keyCode < 106
       },
 
       // @param rawCurrencyInt: 6327397 would represent $63,273.97
@@ -4570,12 +4586,18 @@ export default { middleware: 'currentOrAdmin-showEdit' }
       // @param currencyStr: '$63,273.97'
       // @return rawCurrencyInt: 6327397
       rawCurrencyIntFromCurrencyStr(currencyStr) {
-        return parseInt(currencyStr.replace(/[^\d]/g, ''))
+        if (currencyStr === '') 
+          return ''
+        else
+          return parseInt(currencyStr.replace(/[^\d]/g, ''))
       },
 
       // @param changedCurrencyStr: '$63,273.397'
       // @return fixedCurrencyStr: '$632,733.97'
-      updateCurrencyStr(changedCurrencyStr) {
+      updateCurrencyStr(evt) {
+        const changedCurrencyStr = evt.target.value
+        const strLenAtStart = changedCurrencyStr.length
+        const cursorPosition = evt.target.selectionStart
         const rawCurrencyInt = this.rawCurrencyIntFromCurrencyStr(changedCurrencyStr)
         let correctedCurrencyStr = ''
         switch (rawCurrencyInt.toString().length) {
@@ -4594,6 +4616,12 @@ export default { middleware: 'currentOrAdmin-showEdit' }
           default:
             correctedCurrencyStr = this.currencyStrFromRawCurrencyInt(rawCurrencyInt)
         }
+        setTimeout(() => {
+          const strLenAtEnd = correctedCurrencyStr.length
+          const cursorPositionOffset = strLenAtEnd - strLenAtStart
+          const newCursorPosition = cursorPosition + cursorPositionOffset
+          this.$refs.input.setSelectionRange(newCursorPosition, newCursorPosition);
+        });
         return correctedCurrencyStr
       }
     }

--- a/back/app/controllers/application_controller.rb
+++ b/back/app/controllers/application_controller.rb
@@ -97,6 +97,7 @@ class ApplicationController < ActionController::API
       prep_raw_document(document)
     end
     maintenance = maintenance.slice(:id, :date, :description, :vendor, :cost, :car_id)
+    maintenance['cost'] = number_to_currency(maintenance['cost'])
     maintenance['carId'] = car.id
     maintenance['carName'] = car.name
     maintenance['userId'] = user.id

--- a/back/app/controllers/application_controller.rb
+++ b/back/app/controllers/application_controller.rb
@@ -80,6 +80,7 @@ class ApplicationController < ActionController::API
     image = car.image.present? ? url_for(car.image) : nil
     car = car.slice(:id, :name, :year, :make, :model, :trim, :body, :color, :plate, :vin, :cost, :initial_mileage, :purchase_date,
                     :purchase_vendor)
+    car['cost'] = number_to_currency(car['cost'])
     car['userId'] = user_id
     car['userName'] = user_name
     car['image'] = image
@@ -132,6 +133,14 @@ class ApplicationController < ActionController::API
     document['userName'] = user.name
     document
   end
+
+  def number_to_currency(amount)
+    ActionController::Base.helpers.number_to_currency(amount)
+  end
+
+  def currency_to_number currency
+    currency.to_s.gsub(/[$,]/,'').to_f
+   end
 
   private
 

--- a/back/app/controllers/application_controller.rb
+++ b/back/app/controllers/application_controller.rb
@@ -141,7 +141,7 @@ class ApplicationController < ActionController::API
 
   def currency_to_number currency
     currency.to_s.gsub(/[$,]/,'').to_f
-   end
+  end
 
   private
 

--- a/back/app/controllers/application_controller.rb
+++ b/back/app/controllers/application_controller.rb
@@ -139,7 +139,7 @@ class ApplicationController < ActionController::API
     ActionController::Base.helpers.number_to_currency(amount)
   end
 
-  def currency_to_number currency
+  def currency_to_number(currency)
     currency.to_s.gsub(/[$,]/,'').to_f
   end
 

--- a/back/app/controllers/cars_controller.rb
+++ b/back/app/controllers/cars_controller.rb
@@ -22,6 +22,7 @@ class CarsController < ApplicationController
   def create
     create_params = car_params
     create_params['image'] = params['image'].presence # if no image is chosen on new car page, params['image'] comes in as a blank string, which throws a 500 error at User.new(user_params). This changes any params['avatar'] blank string to nil, which is fine in User.new(user_params).
+    create_params['cost'] = currency_to_number(create_params['cost'])
     @car = Car.new(create_params)
     if @car.save
       render json: prep_raw_car(@car), status: :created, location: @car
@@ -32,7 +33,9 @@ class CarsController < ApplicationController
 
   # PATCH/PUT /cars/1
   def update
-    if @car.update(car_params)
+    edit_params = car_params
+    edit_params['cost'] = currency_to_number(edit_params['cost'])
+    if @car.update(edit_params)
       render json: prep_raw_car(@car)
     else
       render json: @car.errors, status: :unprocessable_entity

--- a/back/app/controllers/maintenances_controller.rb
+++ b/back/app/controllers/maintenances_controller.rb
@@ -25,6 +25,7 @@ class MaintenancesController < ApplicationController
     create_params = maintenance_params
     # create_params['images'] = params['images'].blank? ? nil : params['images'] # if no image is chosen on new maintenance page, params['image'] comes in as a blank string, which throws a 500 error at Maintenance.new(create_params). This changes any params['image'] blank string to nil, which is fine in Maintenance.new(create_params).
     create_params['car_id'] = create_params['car_id'].to_i
+    create_params['cost'] = currency_to_number(create_params['cost'])
     @maintenance = Maintenance.new(create_params)
     if @maintenance.save
       prepped_maintenance = prep_raw_maintenance(@maintenance)
@@ -36,7 +37,9 @@ class MaintenancesController < ApplicationController
 
   # PATCH/PUT /maintenances/1
   def update
-    if @maintenance.update(maintenance_params)
+    edit_params = maintenance_params
+    edit_params['cost'] = currency_to_number(edit_params['cost'])
+    if @maintenance.update(edit_params)
       render json: prep_raw_maintenance(@maintenance)
     else
       render json: @maintenance.errors, status: :unprocessable_entity

--- a/front/assets/scss/main.scss
+++ b/front/assets/scss/main.scss
@@ -3,8 +3,15 @@
 // Pico overrides 
 // $primary-500: #e91e63;
 
-h1 {
-  margin: 4rem 0 0
+.container {
+  h1 {
+    margin: 4rem 0
+  }
+  &.home {
+    h1 {
+      margin: 4rem 0 0
+    }
+  }
 }
 
 .subtitle {

--- a/front/components/CurrencyInput.vue
+++ b/front/components/CurrencyInput.vue
@@ -1,0 +1,94 @@
+<template>
+  <input v-model="val" @keydown="discardIllegalKeys" @keyup="processKeyUp" />
+</template>
+<script>
+  export default {
+    data() {
+      return {
+        val: ''
+      }
+    },
+
+    methods: {
+
+      processKeyUp() {
+        this.val = this.correctChangedCurrencyStr(this.val)
+      },
+
+      discardIllegalKeys(evt) {
+        if (!this.isNumKey(evt) && !this.isArrowBackspaceOrDeleteKey(evt)) {
+          evt.preventDefault()
+        }
+      },
+
+      isArrowBackspaceOrDeleteKey(evt) {
+        const keyCode = evt.keyCode
+        const isDelete = keyCode === 8
+        const isBackspace = keyCode === 46
+        const isArrow = keyCode > 36 && keyCode < 41
+        return (isDelete || isBackspace || isArrow) ? true : false
+      },
+
+      isNumKey(evt) {
+        return evt.key.match(/[0-9]/) ? true : false
+      },
+
+      // @param rawCurrencyInt: 6327397 would represent $63,273.97
+      // @return allButLastTwoWithCommas: '63,273'
+      dollarsStrFromRawCurrencyInt(rawCurrencyInt) {
+        const allButLastTwo = rawCurrencyInt.toString().slice(0, -2)
+        const addCommasRegex = /\B(?=(\d{3})+(?!\d))/g
+        const allButLastTwoWithCommas = allButLastTwo.replace(addCommasRegex, ',')
+        return allButLastTwoWithCommas
+      },
+
+      // @param rawCurrencyInt: 6327397 would represent $63,273.97
+      // @return lastTwo: '97'
+      centsStrFromRawCurrencyInt(rawCurrencyInt) {
+        const lastTwo = rawCurrencyInt.toString().slice(-2)
+        return lastTwo
+      },
+
+      currencyStrFromDollarsAndCents(dollars, cents) {
+        return `$${dollars}.${cents}`
+      },
+
+      currencyStrFromRawCurrencyInt(rawCurrencyInt) {
+        const dollars = this.dollarsStrFromRawCurrencyInt(rawCurrencyInt)
+        const cents = this.centsStrFromRawCurrencyInt(rawCurrencyInt)
+        return this.currencyStrFromDollarsAndCents(dollars, cents)
+      },
+
+      // @param currencyStr: '$63,273.97'
+      // @return rawCurrencyInt: 6327397
+      rawCurrencyIntFromCurrencyStr(currencyStr) {
+        return parseInt(currencyStr.replace(/[^\d]/g, ''))
+      },
+
+      // @param changedCurrencyStr: '$63,273.397'
+      // @return fixedCurrencyStr: '$632,733.97'
+      correctChangedCurrencyStr(changedCurrencyStr) {
+        const rawCurrencyInt = this.rawCurrencyIntFromCurrencyStr(changedCurrencyStr)
+        let correctedCurrencyStr = ''
+        switch (rawCurrencyInt.toString().length) {
+          case 0:
+            break
+          case 1:
+            correctedCurrencyStr = `$0.0${rawCurrencyInt}`;
+            break
+          case 2:
+            correctedCurrencyStr = `$0.${rawCurrencyInt}`;
+            break
+          case 3:
+          case 4:
+            correctedCurrencyStr = this.currencyStrFromRawCurrencyInt(rawCurrencyInt)
+            break
+          default:
+            correctedCurrencyStr = this.currencyStrFromRawCurrencyInt(rawCurrencyInt)
+        }
+        return correctedCurrencyStr
+      }
+
+    }
+  }
+</script>

--- a/front/components/CurrencyInput.vue
+++ b/front/components/CurrencyInput.vue
@@ -1,30 +1,46 @@
 <template>
   <input 
     v-bind:value="value"
-    v-on:input="$emit('input', updateCurrencyStr($event.target.value))"
+    v-on:keydown="discardIllegalEntries($event)"
+    v-on:input="$emit('input', updateCurrencyStr($event))"
+    ref="input"
   />
 </template>
 <script>
+  import { ref } from 'vue'
   export default {
     props: ['value'],
+    setup() {
+      const input = ref(null)
+      return {
+        input
+      }
+    },
     methods: {
-      discardIllegalKeys(evt) {
-        if (!this.isNumKey(evt) && !this.isArrowBackspaceOrDeleteKey(evt)) {
+      discardIllegalEntries(evt) {
+        if (this.isIllegalEntry(evt)) {
           evt.preventDefault()
         }
       },
 
-      // TODO - add a check for command + a
-      isArrowBackspaceOrDeleteKey(evt) {
+      isIllegalEntry(evt) {
+        if (evt.altKey || evt.ctrlKey || evt.metaKey) return false  // we don't care what's pressed if alt, ctrl or command are also held down
         const keyCode = evt.keyCode
-        const isDelete = keyCode === 8
-        const isBackspace = keyCode === 46
-        const isArrow = keyCode > 36 && keyCode < 41
-        return (isDelete || isBackspace || isArrow) ? true : false
+        const is58To90 = keyCode > 57 && keyCode < 91               // 58-90 are punctuation, math symbols and letters
+        const is106To111 = keyCode > 105 && keyCode < 112           // 106-111 are math operation symbols
+        const is160 = keyCode === 160                               // 160 is ^ symbol
+        const is163To165 = keyCode > 162 && keyCode < 166           // 163-165 are currency symbols
+        const is169To173 = keyCode > 168 && keyCode < 174           // 169-173 are copyright, trademark, registered, section, dash
+        const is186To223 = keyCode > 185 && keyCode < 224           // 186-223 are punctuation, symbols, math symbols
+        const is226 = keyCode === 226                               // 226 is < symbol
+        const isShiftPlusNumber = evt.shiftKey && this.isNumber(keyCode)
+        const illegalEntries = [is58To90, is106To111, is160, is163To165, is169To173, is186To223, is226, isShiftPlusNumber]
+        const isEntryIllegal = illegalEntries.some(Boolean)         // are any vals in array truthy, https://www.30secondsofcode.org/js/s/check-array-values-are-truthy/#check-if-all-values-in-an-array-are-truthy
+        return isEntryIllegal
       },
 
-      isNumKey(evt) {
-        return evt.key.match(/[0-9]/) ? true : false
+      isNumber(keyCode) {
+        return keyCode > 47 && keyCode < 58 || keyCode > 95 && keyCode < 106
       },
 
       // @param rawCurrencyInt: 6327397 would represent $63,273.97
@@ -56,12 +72,18 @@
       // @param currencyStr: '$63,273.97'
       // @return rawCurrencyInt: 6327397
       rawCurrencyIntFromCurrencyStr(currencyStr) {
-        return parseInt(currencyStr.replace(/[^\d]/g, ''))
+        if (currencyStr === '') 
+          return ''
+        else
+          return parseInt(currencyStr.replace(/[^\d]/g, ''))
       },
 
       // @param changedCurrencyStr: '$63,273.397'
       // @return fixedCurrencyStr: '$632,733.97'
-      updateCurrencyStr(changedCurrencyStr) {
+      updateCurrencyStr(evt) {
+        const changedCurrencyStr = evt.target.value
+        const strLenAtStart = changedCurrencyStr.length
+        const cursorPosition = evt.target.selectionStart
         const rawCurrencyInt = this.rawCurrencyIntFromCurrencyStr(changedCurrencyStr)
         let correctedCurrencyStr = ''
         switch (rawCurrencyInt.toString().length) {
@@ -80,6 +102,12 @@
           default:
             correctedCurrencyStr = this.currencyStrFromRawCurrencyInt(rawCurrencyInt)
         }
+        setTimeout(() => {
+          const strLenAtEnd = correctedCurrencyStr.length
+          const cursorPositionOffset = strLenAtEnd - strLenAtStart
+          const newCursorPosition = cursorPosition + cursorPositionOffset
+          this.$refs.input.setSelectionRange(newCursorPosition, newCursorPosition);
+        });
         return correctedCurrencyStr
       }
     }

--- a/front/components/CurrencyInput.vue
+++ b/front/components/CurrencyInput.vue
@@ -14,6 +14,7 @@
         }
       },
 
+      // TODO - add a check for command + a
       isArrowBackspaceOrDeleteKey(evt) {
         const keyCode = evt.keyCode
         const isDelete = keyCode === 8

--- a/front/components/CurrencyInput.vue
+++ b/front/components/CurrencyInput.vue
@@ -1,20 +1,13 @@
 <template>
-  <input v-model="val" @keydown="discardIllegalKeys" @keyup="processKeyUp" />
+  <input 
+    v-bind:value="value"
+    v-on:input="$emit('input', updateCurrencyStr($event.target.value))"
+  />
 </template>
 <script>
   export default {
-    data() {
-      return {
-        val: ''
-      }
-    },
-
+    props: ['value'],
     methods: {
-
-      processKeyUp() {
-        this.val = this.correctChangedCurrencyStr(this.val)
-      },
-
       discardIllegalKeys(evt) {
         if (!this.isNumKey(evt) && !this.isArrowBackspaceOrDeleteKey(evt)) {
           evt.preventDefault()
@@ -67,7 +60,7 @@
 
       // @param changedCurrencyStr: '$63,273.397'
       // @return fixedCurrencyStr: '$632,733.97'
-      correctChangedCurrencyStr(changedCurrencyStr) {
+      updateCurrencyStr(changedCurrencyStr) {
         const rawCurrencyInt = this.rawCurrencyIntFromCurrencyStr(changedCurrencyStr)
         let correctedCurrencyStr = ''
         switch (rawCurrencyInt.toString().length) {
@@ -88,7 +81,6 @@
         }
         return correctedCurrencyStr
       }
-
     }
   }
 </script>

--- a/front/components/car/Form.vue
+++ b/front/components/car/Form.vue
@@ -17,7 +17,7 @@
         <p>color: </p><input v-model="color">
         <p>plate: </p><input v-model="plate">
         <p>vin: </p><input v-model="vin">
-        <p>cost: </p><input v-model="cost">
+        <p>cost: </p><CurrencyInput />
         <p>initial_mileage: </p><input v-model="initial_mileage">
         <p>purchase_date: </p><date-picker v-model="purchase_date" valueType="format"></date-picker>
         <p>purchase_vendor: </p><input v-model="purchase_vendor">

--- a/front/components/car/Form.vue
+++ b/front/components/car/Form.vue
@@ -17,7 +17,7 @@
         <p>color: </p><input v-model="color">
         <p>plate: </p><input v-model="plate">
         <p>vin: </p><input v-model="vin">
-        <p>cost!: </p><CurrencyInput v-model="cost" />
+        <p>cost: </p><CurrencyInput v-model="cost" />
         <p>initial_mileage: </p><input v-model="initial_mileage">
         <p>purchase_date: </p><date-picker v-model="purchase_date" valueType="format"></date-picker>
         <p>purchase_vendor: </p><input v-model="purchase_vendor">

--- a/front/components/car/Form.vue
+++ b/front/components/car/Form.vue
@@ -17,7 +17,7 @@
         <p>color: </p><input v-model="color">
         <p>plate: </p><input v-model="plate">
         <p>vin: </p><input v-model="vin">
-        <p>cost: </p><CurrencyInput />
+        <p>cost!: </p><CurrencyInput v-model="cost" />
         <p>initial_mileage: </p><input v-model="initial_mileage">
         <p>purchase_date: </p><date-picker v-model="purchase_date" valueType="format"></date-picker>
         <p>purchase_vendor: </p><input v-model="purchase_vendor">

--- a/front/components/document/Form.vue
+++ b/front/components/document/Form.vue
@@ -105,19 +105,15 @@ export default {
       this.cars = user.cars
       this.maintenances = user.maintenances
       this.documents = user.documents
-      console.log(this.maintenances)
     },
     createDocument: function() {
       const params = {
         'date': this.date,
         'name': this.name,
         'notes': this.notes,
-        // 'attachment': this.attachment,
         'documentable_type': this.carOrMaintenance,
         'documentable_id': parseInt(this.documentableId)
       }
-      console.log("params")
-      console.log(params)
       let payload = new FormData()
       Object.entries(params).forEach(
         ([key, value]) => payload.append(key, value)

--- a/front/components/maintenance/Form.vue
+++ b/front/components/maintenance/Form.vue
@@ -56,7 +56,6 @@ export default {
     this.editOrNew = $nuxt.$route.path.split('/')[$nuxt.$route.path.split('/').length-1]
     if ($nuxt.$route.path.split('/')[$nuxt.$route.path.split('/').length-1]=='edit') {
       const maintenance = await this.$axios.$get(`maintenances/${this.$route.params.id}`)
-      console.log(maintenance)
       this.date = maintenance.date
       this.description = maintenance.description,
       this.vendor = maintenance.vendor

--- a/front/components/maintenance/Form.vue
+++ b/front/components/maintenance/Form.vue
@@ -8,7 +8,7 @@
         <p>Date: </p><date-picker v-model="date" valueType="format"></date-picker>
         <p>Description: </p><input v-model="description">
         <p>Vendor: </p><input v-model="vendor">
-        <p>Cost: </p><input v-model="cost">
+        <p>Cost: </p><CurrencyInput v-model="cost" />
         <!-- <p class="no-margin">Image: </p>
         <img v-if="!hideImage && editOrNew === 'edit'" :src="image" />    
         <input type="file" ref="inputFile" @change=uploadImage()> -->

--- a/front/pages/index.vue
+++ b/front/pages/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <main class="container">
+  <main class="home container">
     <h1>Drivetracks</h1>
     <p class="subtitle">Cloud Car Document Storage</p>
     <img class="challenger" :src="require(`@/assets/images/challenger.png`)" />

--- a/install.sh
+++ b/install.sh
@@ -1093,27 +1093,22 @@ class ApplicationController < ActionController::API
     # maintenances = maintenances.map { |maintenance| maintenance.slice(:id,:name,:description,:car_id) }
     image = car.image.present? ? url_for(car.image) : nil
     car = car.slice(:id,:name,:year,:make,:model,:trim,:body,:color,:plate,:vin,:cost,:initial_mileage,:purchase_date,:purchase_vendor)
+    car['cost'] = number_to_currency(car['cost'])
     car['userId'] = user_id
     car['userName'] = user_name
     car['image'] = image
     # car['maintenances'] = maintenances
     car
   end
-
-  def prep_raw_maintenance(maintenance)
-    car = Car.find(maintenance.car_id)
-    user = User.find(car.user_id)
-    # images = maintenance.images.present? ? maintenance.images.map { |image| url_for(image) } : nil
-    # documents = Document.where(documentable_id: maintenance.id, documentable_type: "Maintenance").map { |document| prep_raw_document(document) }
-    maintenance = maintenance.slice(:id,:date,:description,:vendor,:cost,:car_id)
-    maintenance['carId'] = car.id
-    maintenance['carName'] = car.name
-    maintenance['userId'] = user.id
-    maintenance['userName'] = user.name
-    # maintenance['documents'] = documents
-    # maintenance['images'] = images
-    maintenance
+  
+  def number_to_currency(amount)
+    ActionController::Base.helpers.number_to_currency(amount)
   end
+
+  def currency_to_number currency
+    currency.to_s.gsub(/[$,]/,'').to_f
+  end
+
   
   private 
   
@@ -1148,6 +1143,7 @@ class CarsController < ApplicationController
   def create
     create_params = car_params
     create_params['image'] = params['image'].blank? ? nil : params['image'] # if no image is chosen on new car page, params['image'] comes in as a blank string, which throws a 500 error at User.new(user_params). This changes any params['avatar'] blank string to nil, which is fine in User.new(user_params).
+    create_params['cost'] = currency_to_number(create_params['cost'])
     @car = Car.new(create_params)
     if @car.save
       render json: prep_raw_car(@car), status: :created, location: @car
@@ -1158,7 +1154,9 @@ class CarsController < ApplicationController
 
   # PATCH/PUT /cars/1
   def update
-    if @car.update(car_params)
+    edit_params = car_params
+    edit_params['cost'] = currency_to_number(edit_params['cost'])
+    if @car.update(edit_params)
       render json: prep_raw_car(@car)
     else
       render json: @car.errors, status: :unprocessable_entity
@@ -2268,6 +2266,7 @@ class MaintenancesController < ApplicationController
     create_params = maintenance_params
     # create_params['images'] = params['images'].blank? ? nil : params['images'] # if no image is chosen on new maintenance page, params['image'] comes in as a blank string, which throws a 500 error at Maintenance.new(create_params). This changes any params['image'] blank string to nil, which is fine in Maintenance.new(create_params).
     create_params['car_id'] = create_params['car_id'].to_i
+    create_params['cost'] = currency_to_number(create_params['cost'])
     @maintenance = Maintenance.new(create_params)
     if @maintenance.save
       prepped_maintenance = prep_raw_maintenance(@maintenance)
@@ -2279,7 +2278,9 @@ class MaintenancesController < ApplicationController
 
   # PATCH/PUT /maintenances/1
   def update
-    if @maintenance.update(maintenance_params)
+    edit_params = maintenance_params
+    edit_params['cost'] = currency_to_number(edit_params['cost'])
+    if @maintenance.update(edit_params)
       render json: prep_raw_maintenance(@maintenance)
     else
       render json: @maintenance.errors, status: :unprocessable_entity
@@ -2383,6 +2384,7 @@ class ApplicationController < ActionController::API
     # documents = documents.map { |document| document.slice(:id,:name,:description,:car_id) }
     image = car.image.present? ? url_for(car.image) : nil
     car = car.slice(:id,:name,:year,:make,:model,:trim,:body,:color,:plate,:vin,:cost,:initial_mileage,:purchase_date,:purchase_vendor)
+    car['cost'] = number_to_currency(car['cost'])
     car['userId'] = user_id
     car['userName'] = user_name
     car['image'] = image
@@ -2397,6 +2399,7 @@ class ApplicationController < ActionController::API
     # images = maintenance.images.present? ? maintenance.images.map { |image| url_for(image) } : nil
     # documents = Document.where(documentable_id: maintenance.id, documentable_type: "Maintenance").map { |document| prep_raw_document(document) }
     maintenance = maintenance.slice(:id,:date,:description,:vendor,:cost,:car_id)
+    maintenance['cost'] = number_to_currency(maintenance['cost'])
     maintenance['carId'] = car.id
     maintenance['carName'] = car.name
     maintenance['userId'] = user.id
@@ -2406,19 +2409,12 @@ class ApplicationController < ActionController::API
     maintenance
   end
 
-  def prep_raw_document(document)
-    car_id = document.car_id
-    car = Car.find(car_id)
-    user = User.find(car.user_id)
-    image = document.image.present? ? url_for(document.image) : nil
-    document = document.slice(:id,:name,:description)
-    document['carId'] = car_id
-    document['carName'] = car.name
-    document['carDescription'] = car.description
-    document['userId'] = user.id
-    document['userName'] = user.name
-    document['image'] = image
-    document
+  def number_to_currency(amount)
+    ActionController::Base.helpers.number_to_currency(amount)
+  end
+
+  def currency_to_number currency
+    currency.to_s.gsub(/[$,]/,'').to_f
   end
   
   private 
@@ -3033,6 +3029,7 @@ class ApplicationController < ActionController::API
     documents = Document.where(documentable_id: car.id, documentable_type: "Car").map { |document| prep_raw_document(document) }
     image = car.image.present? ? url_for(car.image) : nil
     car = car.slice(:id,:name,:year,:make,:model,:trim,:body,:color,:plate,:vin,:cost,:initial_mileage,:purchase_date,:purchase_vendor)
+    car['cost'] = number_to_currency(car['cost'])
     car['userId'] = user_id
     car['userName'] = user_name
     car['image'] = image
@@ -3047,6 +3044,7 @@ class ApplicationController < ActionController::API
     # images = maintenance.images.present? ? maintenance.images.map { |image| url_for(image) } : nil
     documents = Document.where(documentable_id: maintenance.id, documentable_type: "Maintenance").map { |document| prep_raw_document(document) }
     maintenance = maintenance.slice(:id,:date,:description,:vendor,:cost,:car_id)
+    maintenance['cost'] = number_to_currency(maintenance['cost'])
     maintenance['carId'] = car.id
     maintenance['carName'] = car.name
     maintenance['userId'] = user.id
@@ -3082,6 +3080,14 @@ class ApplicationController < ActionController::API
     document['userId'] = user.id
     document['userName'] = user.name
     document
+  end
+
+  def number_to_currency(amount)
+    ActionController::Base.helpers.number_to_currency(amount)
+  end
+
+  def currency_to_number currency
+    currency.to_s.gsub(/[$,]/,'').to_f
   end
   
   private 
@@ -4079,6 +4085,97 @@ EOF
 
 
 echo -e "\n\n🦄 Cars (frontend)\n\n"
+cat <<'EOF' | puravida components/CurrencyInput.vue ~
+<template>
+  <input 
+    v-bind:value="value"
+    v-on:input="$emit('input', updateCurrencyStr($event.target.value))"
+  />
+</template>
+<script>
+  export default {
+    props: ['value'],
+    methods: {
+      discardIllegalKeys(evt) {
+        if (!this.isNumKey(evt) && !this.isArrowBackspaceOrDeleteKey(evt)) {
+          evt.preventDefault()
+        }
+      },
+
+      // TODO - add a check for command + a
+      isArrowBackspaceOrDeleteKey(evt) {
+        const keyCode = evt.keyCode
+        const isDelete = keyCode === 8
+        const isBackspace = keyCode === 46
+        const isArrow = keyCode > 36 && keyCode < 41
+        return (isDelete || isBackspace || isArrow) ? true : false
+      },
+
+      isNumKey(evt) {
+        return evt.key.match(/[0-9]/) ? true : false
+      },
+
+      // @param rawCurrencyInt: 6327397 would represent $63,273.97
+      // @return allButLastTwoWithCommas: '63,273'
+      dollarsStrFromRawCurrencyInt(rawCurrencyInt) {
+        const allButLastTwo = rawCurrencyInt.toString().slice(0, -2)
+        const addCommasRegex = /\B(?=(\d{3})+(?!\d))/g
+        const allButLastTwoWithCommas = allButLastTwo.replace(addCommasRegex, ',')
+        return allButLastTwoWithCommas
+      },
+
+      // @param rawCurrencyInt: 6327397 would represent $63,273.97
+      // @return lastTwo: '97'
+      centsStrFromRawCurrencyInt(rawCurrencyInt) {
+        const lastTwo = rawCurrencyInt.toString().slice(-2)
+        return lastTwo
+      },
+
+      currencyStrFromDollarsAndCents(dollars, cents) {
+        return `$${dollars}.${cents}`
+      },
+
+      currencyStrFromRawCurrencyInt(rawCurrencyInt) {
+        const dollars = this.dollarsStrFromRawCurrencyInt(rawCurrencyInt)
+        const cents = this.centsStrFromRawCurrencyInt(rawCurrencyInt)
+        return this.currencyStrFromDollarsAndCents(dollars, cents)
+      },
+
+      // @param currencyStr: '$63,273.97'
+      // @return rawCurrencyInt: 6327397
+      rawCurrencyIntFromCurrencyStr(currencyStr) {
+        return parseInt(currencyStr.replace(/[^\d]/g, ''))
+      },
+
+      // @param changedCurrencyStr: '$63,273.397'
+      // @return fixedCurrencyStr: '$632,733.97'
+      updateCurrencyStr(changedCurrencyStr) {
+        const rawCurrencyInt = this.rawCurrencyIntFromCurrencyStr(changedCurrencyStr)
+        let correctedCurrencyStr = ''
+        switch (rawCurrencyInt.toString().length) {
+          case 0:
+            break
+          case 1:
+            correctedCurrencyStr = `$0.0${rawCurrencyInt}`;
+            break
+          case 2:
+            correctedCurrencyStr = `$0.${rawCurrencyInt}`;
+            break
+          case 3:
+          case 4:
+            correctedCurrencyStr = this.currencyStrFromRawCurrencyInt(rawCurrencyInt)
+            break
+          default:
+            correctedCurrencyStr = this.currencyStrFromRawCurrencyInt(rawCurrencyInt)
+        }
+        return correctedCurrencyStr
+      }
+    }
+  }
+</script>
+~
+EOF
+
 cat <<'EOF' | puravida components/car/Card.vue ~
 <template>
   <article>
@@ -4207,7 +4304,7 @@ cat <<'EOF' | puravida components/car/Form.vue ~
         <p>color: </p><input v-model="color">
         <p>plate: </p><input v-model="plate">
         <p>vin: </p><input v-model="vin">
-        <p>cost: </p><input v-model="cost">
+        <p>cost: </p><CurrencyInput v-model="cost" />
         <p>initial_mileage: </p><input v-model="initial_mileage">
         <p>purchase_date: </p><date-picker v-model="purchase_date" valueType="format"></date-picker>
         <p>purchase_vendor: </p><input v-model="purchase_vendor">
@@ -4316,9 +4413,13 @@ export default {
       let params = {}
       const filePickerFile = this.$refs.inputFile.files[0]
       if (!filePickerFile) {
+<<<<<<< HEAD
         const userId = this.$auth.$state.user.id
         console.log('user id', userId)
         params = {
+=======
+        params = { 
+>>>>>>> 7f5eeaa (Add CurrencyInput to docs)
           'name': this.name,
           'year': this.year,
           'make': this.make,
@@ -4331,6 +4432,7 @@ export default {
           'cost': this.cost,
           'initial_mileage': this.initial_mileage,
           'purchase_date': this.purchase_date,
+<<<<<<< HEAD
           'purchase_vendor': this.purchase_vendor,
           'user_id': userId
         }
@@ -4339,6 +4441,14 @@ export default {
         params = { 
           'name': this.name,
           'image': this.image, 
+=======
+          'purchase_vendor': this.purchase_vendor
+        }
+      } else {
+        params = { 
+          'name': this.name,
+          'image': this.image,
+>>>>>>> 7f5eeaa (Add CurrencyInput to docs)
           'year': this.year,
           'make': this.make,
           'model': this.model,
@@ -4542,7 +4652,7 @@ cat <<'EOF' | puravida components/maintenance/Form.vue ~
         <p>Date: </p><date-picker v-model="date" valueType="format"></date-picker>
         <p>Description: </p><input v-model="description">
         <p>Vendor: </p><input v-model="vendor">
-        <p>Cost: </p><input v-model="cost">
+        <p>Cost: </p><CurrencyInput v-model="cost" />
         <!-- <p class="no-margin">Image: </p>
         <img v-if="!hideImage && editOrNew === 'edit'" :src="image" />    
         <input type="file" ref="inputFile" @change=uploadImage()> -->

--- a/install.sh
+++ b/install.sh
@@ -3623,8 +3623,15 @@ cat <<'EOF' | puravida assets/scss/main.scss ~
 // Pico overrides 
 // $primary-500: #e91e63;
 
-h1 {
-  margin: 4rem 0 0
+.container {
+  h1 {
+    margin: 4rem 0
+  }
+  &.home {
+    h1 {
+      margin: 4rem 0 0
+    }
+  }
 }
 
 .subtitle {
@@ -4699,7 +4706,6 @@ export default {
     this.editOrNew = $nuxt.$route.path.split('/')[$nuxt.$route.path.split('/').length-1]
     if ($nuxt.$route.path.split('/')[$nuxt.$route.path.split('/').length-1]=='edit') {
       const maintenance = await this.$axios.$get(`maintenances/${this.$route.params.id}`)
-      console.log(maintenance)
       this.date = maintenance.date
       this.description = maintenance.description,
       this.vendor = maintenance.vendor
@@ -5021,7 +5027,6 @@ export default {
       this.cars = user.cars
       this.maintenances = user.maintenances
       this.documents = user.documents
-      console.log(this.maintenances)
     },
     createDocument: function() {
       const params = {
@@ -5032,8 +5037,6 @@ export default {
         'documentable_type': this.carOrMaintenance,
         'documentable_id': parseInt(this.documentableId)
       }
-      console.log("params")
-      console.log(params)
       let payload = new FormData()
       Object.entries(params).forEach(
         ([key, value]) => payload.append(key, value)
@@ -5370,7 +5373,7 @@ EOF
 echo -e "\n\n🦄 Home\n\n"
 cat <<'EOF' | puravida pages/index.vue ~
 <template>
-  <main class="container">
+  <main class="home container">
     <h1>Drivetracks</h1>
     <p class="subtitle">Cloud Car Document Storage</p>
     <img class="challenger" :src="require(`@/assets/images/challenger.png`)" />

--- a/install.sh
+++ b/install.sh
@@ -4096,30 +4096,46 @@ cat <<'EOF' | puravida components/CurrencyInput.vue ~
 <template>
   <input 
     v-bind:value="value"
-    v-on:input="$emit('input', updateCurrencyStr($event.target.value))"
+    v-on:keydown="discardIllegalEntries($event)"
+    v-on:input="$emit('input', updateCurrencyStr($event))"
+    ref="input"
   />
 </template>
 <script>
+  import { ref } from 'vue'
   export default {
     props: ['value'],
+    setup() {
+      const input = ref(null)
+      return {
+        input
+      }
+    },
     methods: {
-      discardIllegalKeys(evt) {
-        if (!this.isNumKey(evt) && !this.isArrowBackspaceOrDeleteKey(evt)) {
+      discardIllegalEntries(evt) {
+        if (this.isIllegalEntry(evt)) {
           evt.preventDefault()
         }
       },
 
-      // TODO - add a check for command + a
-      isArrowBackspaceOrDeleteKey(evt) {
+      isIllegalEntry(evt) {
+        if (evt.altKey || evt.ctrlKey || evt.metaKey) return false  // we don't care what's pressed if alt, ctrl or command are also held down
         const keyCode = evt.keyCode
-        const isDelete = keyCode === 8
-        const isBackspace = keyCode === 46
-        const isArrow = keyCode > 36 && keyCode < 41
-        return (isDelete || isBackspace || isArrow) ? true : false
+        const is58To90 = keyCode > 57 && keyCode < 91               // 58-90 are punctuation, math symbols and letters
+        const is106To111 = keyCode > 105 && keyCode < 112           // 106-111 are math operation symbols
+        const is160 = keyCode === 160                               // 160 is ^ symbol
+        const is163To165 = keyCode > 162 && keyCode < 166           // 163-165 are currency symbols
+        const is169To173 = keyCode > 168 && keyCode < 174           // 169-173 are copyright, trademark, registered, section, dash
+        const is186To223 = keyCode > 185 && keyCode < 224           // 186-223 are punctuation, symbols, math symbols
+        const is226 = keyCode === 226                               // 226 is < symbol
+        const isShiftPlusNumber = evt.shiftKey && this.isNumber(keyCode)
+        const illegalEntries = [is58To90, is106To111, is160, is163To165, is169To173, is186To223, is226, isShiftPlusNumber]
+        const isEntryIllegal = illegalEntries.some(Boolean)         // are any vals in array truthy, https://www.30secondsofcode.org/js/s/check-array-values-are-truthy/#check-if-all-values-in-an-array-are-truthy
+        return isEntryIllegal
       },
 
-      isNumKey(evt) {
-        return evt.key.match(/[0-9]/) ? true : false
+      isNumber(keyCode) {
+        return keyCode > 47 && keyCode < 58 || keyCode > 95 && keyCode < 106
       },
 
       // @param rawCurrencyInt: 6327397 would represent $63,273.97
@@ -4151,12 +4167,18 @@ cat <<'EOF' | puravida components/CurrencyInput.vue ~
       // @param currencyStr: '$63,273.97'
       // @return rawCurrencyInt: 6327397
       rawCurrencyIntFromCurrencyStr(currencyStr) {
-        return parseInt(currencyStr.replace(/[^\d]/g, ''))
+        if (currencyStr === '') 
+          return ''
+        else
+          return parseInt(currencyStr.replace(/[^\d]/g, ''))
       },
 
       // @param changedCurrencyStr: '$63,273.397'
       // @return fixedCurrencyStr: '$632,733.97'
-      updateCurrencyStr(changedCurrencyStr) {
+      updateCurrencyStr(evt) {
+        const changedCurrencyStr = evt.target.value
+        const strLenAtStart = changedCurrencyStr.length
+        const cursorPosition = evt.target.selectionStart
         const rawCurrencyInt = this.rawCurrencyIntFromCurrencyStr(changedCurrencyStr)
         let correctedCurrencyStr = ''
         switch (rawCurrencyInt.toString().length) {
@@ -4175,6 +4197,12 @@ cat <<'EOF' | puravida components/CurrencyInput.vue ~
           default:
             correctedCurrencyStr = this.currencyStrFromRawCurrencyInt(rawCurrencyInt)
         }
+        setTimeout(() => {
+          const strLenAtEnd = correctedCurrencyStr.length
+          const cursorPositionOffset = strLenAtEnd - strLenAtStart
+          const newCursorPosition = cursorPosition + cursorPositionOffset
+          this.$refs.input.setSelectionRange(newCursorPosition, newCursorPosition);
+        });
         return correctedCurrencyStr
       }
     }

--- a/install.sh
+++ b/install.sh
@@ -1105,7 +1105,7 @@ class ApplicationController < ActionController::API
     ActionController::Base.helpers.number_to_currency(amount)
   end
 
-  def currency_to_number currency
+  def currency_to_number(currency)
     currency.to_s.gsub(/[$,]/,'').to_f
   end
 
@@ -2413,7 +2413,7 @@ class ApplicationController < ActionController::API
     ActionController::Base.helpers.number_to_currency(amount)
   end
 
-  def currency_to_number currency
+  def currency_to_number(currency)
     currency.to_s.gsub(/[$,]/,'').to_f
   end
   
@@ -3086,7 +3086,7 @@ class ApplicationController < ActionController::API
     ActionController::Base.helpers.number_to_currency(amount)
   end
 
-  def currency_to_number currency
+  def currency_to_number(currency)
     currency.to_s.gsub(/[$,]/,'').to_f
   end
   


### PR DESCRIPTION
Issue: [Add currency formatting to cost fields](https://github.com/users/mark-mcdermott/projects/1/views/1?pane=issue&itemId=55913955)

Overview: The cost fields on the car/maintenance new/edit pages were plain text inputs which had to take numbers (decimals were ok), but didn't have/add a dollar sign, so it looked pretty strange and was confusing UX. Now when you type a number in those fields it automatically formats it to $00.0x, where x is the number you entered. As you enter more numbers it keeps it in that currency format.

I also added the [Add Padding Under h1 Page Titles](https://github.com/users/mark-mcdermott/projects/1/views/1?pane=issue&itemId=57178420) fix into this PR because it was quick and easy.